### PR TITLE
Test enhancement

### DIFF
--- a/tests/AttributeMiddlewareTest.php
+++ b/tests/AttributeMiddlewareTest.php
@@ -23,7 +23,7 @@ class AttributeMiddlewareTest extends TestCase
     /** @var AttributeMiddleware The middleware to use in tests */
     private $middleware;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->middleware = new AttributeMiddleware();
     }


### PR DESCRIPTION
According to the [PHPUnit fixture reference](https://phpunit.readthedocs.io/en/latest/fixtures.html?highlight=fixtures), the `setUp` method should be `protected`, not `public`.